### PR TITLE
Avoid arrow parenthesis 

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@ module.exports = {
   semi: false,
   singleQuote: true,
   bracketSpacing: false,
-  trailingComma: 'none'
+  trailingComma: 'none',
+  arrowParens: 'avoid'
 }


### PR DESCRIPTION
The default changed from `avoid` to `always` in prettier 2.0

See: https://prettier.io/docs/en/options.html#arrow-function-parentheses