### PR TITLE
set trailing commas to all

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ module.exports = {
   semi: false,
   singleQuote: true,
   bracketSpacing: false,
-  trailingComma: 'es5',
+  trailingComma: 'all',
   arrowParens: 'avoid'
 }


### PR DESCRIPTION
Following on from #18, this sets `trailingCommas` to `all` which is in-line with Prettier v3 (see https://github.com/prettier/prettier/issues/11465)