### PR TITLE
Publish package to GHPR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,24 @@ jobs:
       - run: npm whoami; npm --ignore-scripts publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-github:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          registry-url: https://npm.pkg.github.com
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - run: npm whoami; npm --ignore-scripts publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since there are a few repositories in npm that are currently consuming
GitHub scoped packages directly from GHPR, it'd be convenient if we
could publish the latest version of our packages to both registries.
