### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   publish-npm:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Node CI
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION

- https://github.com/github/prettier-config/security/code-scanning/2
To fix the issue, add a `permissions` block with explicit least privilege to the `publish-npm` job. As the job only needs to publish to npm (using a personal access token from `secrets.npm_token`) and does not perform any package write operations requiring `GITHUB_TOKEN`, the minimum necessary permission is likely `contents: read`. This block should be inserted directly under the job name (immediately after `publish-npm:` and before `runs-on:`) in the `publish-npm` job. No other code changes or imports are required.

  ---
  


- https://github.com/github/prettier-config/security/code-scanning/1
To fix the problem, you should add the `permissions` block to the workflow. Since this workflow does not contain any steps which create or modify repository content, issues, or pull requests, the minimal permission required is `contents: read`. You should add the following block immediately below the `name:` declaration at the top of the `.github/workflows/test.yml` file, which will set this as the default permission for all jobs in the workflow. No changes to existing functionality will occur. No new imports or definitions are required.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
